### PR TITLE
Pull #91: Dotted Identifiers should be a single token

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -22,6 +22,7 @@ public class Main {
             printLexedTokens(tokens);
 
             JavadocParser parser = new JavadocParser(tokens, unclosed);
+            parser.setTrace(true);
             JavadocParser.JavadocContext tree = ParseAndPrintStats(parser);
             printParseTree(tree, parser);
             DisplayTreeInGUI(tree, parser);

--- a/src/main/resources/JavadocParser.g4
+++ b/src/main/resources/JavadocParser.g4
@@ -79,11 +79,11 @@ parameterTag
     ;
 
 throwsTag
-    : AT_SIGN tagName=THROWS exceptionName=qualifiedIdentifier description?
+    : AT_SIGN tagName=THROWS exceptionName=qualifiedName description?
     ;
 
 exceptionTag
-    : AT_SIGN tagName=EXCEPTION exceptionName=qualifiedIdentifier description?
+    : AT_SIGN tagName=EXCEPTION exceptionName=qualifiedName description?
     ;
 
 sinceTag
@@ -104,9 +104,9 @@ seeTag
 
 hiddenTag: AT_SIGN tagName=LITERAL_HIDDEN description?;
 
-usesTag: AT_SIGN tagName=USES serviceType=qualifiedIdentifier description?;
+usesTag: AT_SIGN tagName=USES serviceType=qualifiedName description?;
 
-providesTag: AT_SIGN tagName=PROVIDES serviceType=qualifiedIdentifier description?;
+providesTag: AT_SIGN tagName=PROVIDES serviceType=qualifiedName description?;
 
 serialTag: AT_SIGN tagName=SERIAL description?;
 
@@ -162,7 +162,7 @@ summaryInlineTag
     ;
 
 systemPropertyInlineTag
-    : tagName=SYSTEM_PROPERTY propertyName?
+    : tagName=SYSTEM_PROPERTY propertyName=qualifiedName?
     ;
 
 indexInlineTag
@@ -188,11 +188,15 @@ customInlineTag
 // Components
 reference
     : HASH memberReference
-    | (module=qualifiedName SLASH)? type=qualifiedName (HASH memberReference)?
+    | (module=qualifiedName SLASH)? type=typeName (HASH memberReference)?
+    ;
+
+typeName
+    : qualifiedName (typeArguments)?
     ;
 
 qualifiedName
-    : IDENTIFIER (DOT IDENTIFIER)* typeArguments?
+    : IDENTIFIER
     ;
 
 typeArguments
@@ -200,10 +204,10 @@ typeArguments
     ;
 
 typeArgument
-    : qualifiedName
+    : typeName
     | QUESTION
-    | QUESTION EXTENDS qualifiedName
-    | QUESTION SUPER qualifiedName
+    | QUESTION EXTENDS typeName
+    | QUESTION SUPER typeName
     ;
 
 memberReference
@@ -214,10 +218,6 @@ parameterTypeList
     : PARAMETER_TYPE (COMMA PARAMETER_TYPE)*
     ;
 
-propertyName
-    : IDENTIFIER (DOT IDENTIFIER)*
-    ;
-
 snippetAttribute
     : SNIPPET_ATTR_NAME EQUALS ATTRIBUTE_VALUE
     ;
@@ -225,8 +225,6 @@ snippetAttribute
 snippetBody
     : TEXT+
     ;
-
-qualifiedIdentifier: IDENTIFIER;
 
 description
     : (TEXT | inlineTag | htmlElement)+

--- a/src/test/resources/blockThrows.txt
+++ b/src/test/resources/blockThrows.txt
@@ -2,42 +2,42 @@
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 1, column: 2]
    |  |- TOKEN[type: THROWS, text: throws, line: 1, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: IOException, line: 1, column: 10]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  if the file cannot be read., line: 1, column: 21]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 2, column: 2]
    |  |- TOKEN[type: THROWS, text: throws, line: 2, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: NullPointerException, line: 2, column: 10]
    |  '- description
    |     '- TOKEN[type: TEXT, text: if the input file is null., line: 3, column: 6]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 4, column: 2]
    |  |- TOKEN[type: THROWS, text: throws, line: 4, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: NullPointerException, line: 5, column: 6]
    |  '- description
    |     '- TOKEN[type: TEXT, text: if the input file is null., line: 6, column: 6]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 7, column: 2]
    |  |- TOKEN[type: EXCEPTION, text: exception, line: 7, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: IllegalStateException, line: 7, column: 13]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  when called in an invalid state, line: 7, column: 34]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 8, column: 2]
    |  |- TOKEN[type: EXCEPTION, text: exception, line: 8, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: UnexpectedErrorException, line: 9, column: 6]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  if something very unexpected happens., line: 9, column: 30]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 10, column: 2]
    |  |- TOKEN[type: EXCEPTION, text: exception, line: 10, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: CustomUncheckedException, line: 10, column: 13]
    |  '- description
    |     |- TOKEN[type: JAVADOC_INLINE_TAG_START, text: {@, line: 11, column: 10]
@@ -47,11 +47,11 @@
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 12, column: 2]
    |  |- TOKEN[type: THROWS, text: throws, line: 12, column: 3]
-   |  '- qualifiedIdentifier
+   |  '- qualifiedName
    |     '- TOKEN[type: IDENTIFIER, text: IOException, line: 12, column: 10]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 13, column: 2]
    |  |- TOKEN[type: EXCEPTION, text: exception, line: 13, column: 3]
-   |  '- qualifiedIdentifier
+   |  '- qualifiedName
    |     '- TOKEN[type: IDENTIFIER, text: SecurityException, line: 13, column: 13]
    '- TOKEN[type: EOF, text: <EOF>, line: 13, column: 30]

--- a/src/test/resources/blockUsesAndProvides.txt
+++ b/src/test/resources/blockUsesAndProvides.txt
@@ -2,25 +2,25 @@
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 1, column: 2]
    |  |- TOKEN[type: USES, text: uses, line: 1, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: testpkgmdlB.TestClassInModuleB, line: 1, column: 8]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  With a test description for uses., line: 1, column: 38]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 2, column: 2]
    |  |- TOKEN[type: PROVIDES, text: provides, line: 2, column: 3]
-   |  '- qualifiedIdentifier
+   |  '- qualifiedName
    |     '- TOKEN[type: IDENTIFIER, text: testpkg2mdlB.TestInterface2InModuleB, line: 2, column: 12]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 3, column: 2]
    |  |- TOKEN[type: PROVIDES, text: provides, line: 3, column: 3]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: testpkgmdlB.TestClassInModuleB, line: 3, column: 12]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  With a test description for provides., line: 3, column: 42]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 4, column: 2]
    |  |- TOKEN[type: USES, text: uses, line: 4, column: 3]
-   |  '- qualifiedIdentifier
+   |  '- qualifiedName
    |     '- TOKEN[type: IDENTIFIER, text: com.sun.net.httpserver.spi.HttpServerProvider, line: 4, column: 8]
    '- TOKEN[type: EOF, text: <EOF>, line: 4, column: 53]

--- a/src/test/resources/blockVersion.txt
+++ b/src/test/resources/blockVersion.txt
@@ -29,11 +29,7 @@
    |     |  |- linkInlineTag
    |     |  |  |- TOKEN[type: LINK, text: link, line: 6, column: 13]
    |     |  |  '- reference
-   |     |  |     |- TOKEN[type: IDENTIFIER, text: java, line: 6, column: 18]
-   |     |  |     |- TOKEN[type: DOT, text: ., line: 6, column: 22]
-   |     |  |     |- TOKEN[type: IDENTIFIER, text: util, line: 6, column: 23]
-   |     |  |     |- TOKEN[type: DOT, text: ., line: 6, column: 27]
-   |     |  |     '- TOKEN[type: IDENTIFIER, text: List, line: 6, column: 28]
+   |     |  |     '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 6, column: 18]
    |     |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 6, column: 32]
    |     '- TOKEN[type: TEXT, text:  v3.1, line: 6, column: 33]
    |- blockTag

--- a/src/test/resources/complex.txt
+++ b/src/test/resources/complex.txt
@@ -36,12 +36,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 3, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 3, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 3, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 3, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 3, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 3, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 3, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 3, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 3, column: 36]
@@ -111,12 +107,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 4, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 4, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 4, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 4, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 4, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 4, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 4, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 4, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 4, column: 36]
@@ -186,12 +178,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 5, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 5, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 5, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 5, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 5, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 5, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 5, column: 36]
@@ -261,12 +249,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 6, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 6, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 6, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 6, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 6, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 6, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 6, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 6, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 6, column: 36]
@@ -336,12 +320,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 7, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 7, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 7, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 7, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 7, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 7, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 7, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 7, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 7, column: 36]
@@ -411,12 +391,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 8, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 8, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 8, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 8, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 8, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 8, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 8, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 8, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 8, column: 36]
@@ -486,12 +462,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 9, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 9, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 9, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 9, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 9, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 9, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 9, column: 36]
@@ -561,12 +533,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 10, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 10, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 10, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 10, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 10, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 10, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 10, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 10, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 10, column: 36]
@@ -636,12 +604,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 11, column: 16]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 11, column: 21]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 11, column: 25]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 11, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 11, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 11, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 11, column: 21]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 11, column: 35]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 11, column: 36]
@@ -711,12 +675,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 12, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 12, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 12, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 12, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 12, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 12, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 12, column: 37]
@@ -786,12 +746,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 13, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 13, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 13, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 13, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 13, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 13, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 13, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 13, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 13, column: 37]
@@ -861,12 +817,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 14, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 14, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 14, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 14, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 14, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 14, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 14, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 14, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 14, column: 37]
@@ -936,12 +888,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 15, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 15, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 15, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 15, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 15, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 15, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 15, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 15, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 15, column: 37]
@@ -1011,12 +959,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 16, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 16, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 16, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 16, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 16, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 16, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 16, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 16, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 16, column: 37]
@@ -1086,12 +1030,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 17, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 17, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 17, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 17, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 17, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 17, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 17, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 17, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 17, column: 37]
@@ -1161,12 +1101,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 18, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 18, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 18, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 18, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 18, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 18, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 18, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 18, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 18, column: 37]
@@ -1236,12 +1172,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 19, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 19, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 19, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 19, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 19, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 19, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 19, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 19, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 19, column: 37]
@@ -1311,12 +1243,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 20, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 20, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 20, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 20, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 20, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 20, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 20, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 20, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 20, column: 37]
@@ -1386,12 +1314,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 21, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 21, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 21, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 21, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 21, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 21, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 21, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 21, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 21, column: 37]
@@ -1461,12 +1385,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 22, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 22, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 22, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 22, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 22, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 22, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 22, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 22, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 22, column: 37]
@@ -1536,12 +1456,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 23, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 23, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 23, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 23, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 23, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 23, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 23, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 23, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 23, column: 37]
@@ -1611,12 +1527,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 24, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 24, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 24, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 24, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 24, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 24, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 24, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 24, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 24, column: 37]
@@ -1686,12 +1598,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 25, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 25, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 25, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 25, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 25, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 25, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 25, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 25, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 25, column: 37]
@@ -1761,12 +1669,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 26, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 26, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 26, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 26, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 26, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 26, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 26, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 26, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 26, column: 37]
@@ -1836,12 +1740,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 27, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 27, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 27, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 27, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 27, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 27, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 27, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 27, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 27, column: 37]
@@ -1911,12 +1811,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 28, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 28, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 28, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 28, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 28, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 28, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 28, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 28, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 28, column: 37]
@@ -1986,12 +1882,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 29, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 29, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 29, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 29, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 29, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 29, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 29, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 29, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 29, column: 37]
@@ -2061,12 +1953,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 30, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 30, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 30, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 30, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 30, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 30, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 30, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 30, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 30, column: 37]
@@ -2136,12 +2024,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 31, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 31, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 31, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 31, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 31, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 31, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 31, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 31, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 31, column: 37]
@@ -2211,12 +2095,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 32, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 32, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 32, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 32, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 32, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 32, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 32, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 32, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 32, column: 37]
@@ -2286,12 +2166,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 33, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 33, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 33, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 33, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 33, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 33, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 33, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 33, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 33, column: 37]
@@ -2361,12 +2237,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 34, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 34, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 34, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 34, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 34, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 34, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 34, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 34, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 34, column: 37]
@@ -2436,12 +2308,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 35, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 35, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 35, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 35, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 35, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 35, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 35, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 35, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 35, column: 37]
@@ -2511,12 +2379,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 36, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 36, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 36, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 36, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 36, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 36, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 36, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 36, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 36, column: 37]
@@ -2586,12 +2450,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 37, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 37, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 37, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 37, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 37, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 37, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 37, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 37, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 37, column: 37]
@@ -2661,12 +2521,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 38, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 38, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 38, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 38, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 38, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 38, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 38, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 38, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 38, column: 37]
@@ -2736,12 +2592,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 39, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 39, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 39, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 39, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 39, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 39, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 39, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 39, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 39, column: 37]
@@ -2811,12 +2663,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 40, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 40, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 40, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 40, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 40, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 40, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 40, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 40, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 40, column: 37]
@@ -2886,12 +2734,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 41, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 41, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 41, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 41, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 41, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 41, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 41, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 41, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 41, column: 37]
@@ -2961,12 +2805,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 42, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 42, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 42, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 42, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 42, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 42, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 42, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 42, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 42, column: 37]
@@ -3036,12 +2876,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 43, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 43, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 43, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 43, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 43, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 43, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 43, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 43, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 43, column: 37]
@@ -3111,12 +2947,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 44, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 44, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 44, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 44, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 44, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 44, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 44, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 44, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 44, column: 37]
@@ -3186,12 +3018,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 45, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 45, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 45, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 45, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 45, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 45, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 45, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 45, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 45, column: 37]
@@ -3261,12 +3089,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 46, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 46, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 46, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 46, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 46, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 46, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 46, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 46, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 46, column: 37]
@@ -3336,12 +3160,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 47, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 47, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 47, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 47, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 47, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 47, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 47, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 47, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 47, column: 37]
@@ -3411,12 +3231,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 48, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 48, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 48, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 48, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 48, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 48, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 48, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 48, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 48, column: 37]
@@ -3486,12 +3302,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 49, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 49, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 49, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 49, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 49, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 49, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 49, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 49, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 49, column: 37]
@@ -3561,12 +3373,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 50, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 50, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 50, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 50, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 50, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 50, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 50, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 50, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 50, column: 37]
@@ -3636,12 +3444,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 51, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 51, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 51, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 51, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 51, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 51, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 51, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 51, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 51, column: 37]
@@ -3711,12 +3515,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 52, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 52, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 52, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 52, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 52, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 52, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 52, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 52, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 52, column: 37]
@@ -3786,12 +3586,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 53, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 53, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 53, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 53, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 53, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 53, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 53, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 53, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 53, column: 37]
@@ -3861,12 +3657,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 54, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 54, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 54, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 54, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 54, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 54, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 54, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 54, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 54, column: 37]
@@ -3936,12 +3728,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 55, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 55, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 55, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 55, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 55, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 55, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 55, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 55, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 55, column: 37]
@@ -4011,12 +3799,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 56, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 56, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 56, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 56, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 56, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 56, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 56, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 56, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 56, column: 37]
@@ -4086,12 +3870,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 57, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 57, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 57, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 57, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 57, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 57, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 57, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 57, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 57, column: 37]
@@ -4161,12 +3941,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 58, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 58, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 58, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 58, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 58, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 58, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 58, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 58, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 58, column: 37]
@@ -4236,12 +4012,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 59, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 59, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 59, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 59, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 59, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 59, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 59, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 59, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 59, column: 37]
@@ -4311,12 +4083,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 60, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 60, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 60, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 60, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 60, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 60, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 60, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 60, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 60, column: 37]
@@ -4386,12 +4154,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 61, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 61, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 61, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 61, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 61, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 61, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 61, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 61, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 61, column: 37]
@@ -4461,12 +4225,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 62, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 62, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 62, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 62, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 62, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 62, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 62, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 62, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 62, column: 37]
@@ -4536,12 +4296,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 63, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 63, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 63, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 63, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 63, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 63, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 63, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 63, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 63, column: 37]
@@ -4611,12 +4367,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 64, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 64, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 64, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 64, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 64, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 64, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 64, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 64, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 64, column: 37]
@@ -4686,12 +4438,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 65, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 65, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 65, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 65, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 65, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 65, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 65, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 65, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 65, column: 37]
@@ -4761,12 +4509,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 66, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 66, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 66, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 66, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 66, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 66, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 66, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 66, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 66, column: 37]
@@ -4836,12 +4580,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 67, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 67, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 67, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 67, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 67, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 67, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 67, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 67, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 67, column: 37]
@@ -4911,12 +4651,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 68, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 68, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 68, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 68, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 68, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 68, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 68, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 68, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 68, column: 37]
@@ -4986,12 +4722,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 69, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 69, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 69, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 69, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 69, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 69, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 69, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 69, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 69, column: 37]
@@ -5061,12 +4793,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 70, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 70, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 70, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 70, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 70, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 70, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 70, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 70, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 70, column: 37]
@@ -5136,12 +4864,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 71, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 71, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 71, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 71, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 71, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 71, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 71, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 71, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 71, column: 37]
@@ -5211,12 +4935,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 72, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 72, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 72, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 72, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 72, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 72, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 72, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 72, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 72, column: 37]
@@ -5286,12 +5006,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 73, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 73, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 73, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 73, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 73, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 73, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 73, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 73, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 73, column: 37]
@@ -5361,12 +5077,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 74, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 74, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 74, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 74, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 74, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 74, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 74, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 74, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 74, column: 37]
@@ -5436,12 +5148,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 75, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 75, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 75, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 75, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 75, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 75, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 75, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 75, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 75, column: 37]
@@ -5511,12 +5219,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 76, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 76, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 76, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 76, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 76, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 76, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 76, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 76, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 76, column: 37]
@@ -5586,12 +5290,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 77, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 77, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 77, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 77, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 77, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 77, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 77, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 77, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 77, column: 37]
@@ -5661,12 +5361,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 78, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 78, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 78, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 78, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 78, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 78, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 78, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 78, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 78, column: 37]
@@ -5736,12 +5432,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 79, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 79, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 79, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 79, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 79, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 79, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 79, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 79, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 79, column: 37]
@@ -5811,12 +5503,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 80, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 80, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 80, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 80, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 80, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 80, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 80, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 80, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 80, column: 37]
@@ -5886,12 +5574,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 81, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 81, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 81, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 81, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 81, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 81, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 81, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 81, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 81, column: 37]
@@ -5961,12 +5645,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 82, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 82, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 82, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 82, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 82, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 82, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 82, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 82, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 82, column: 37]
@@ -6036,12 +5716,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 83, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 83, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 83, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 83, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 83, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 83, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 83, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 83, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 83, column: 37]
@@ -6111,12 +5787,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 84, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 84, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 84, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 84, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 84, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 84, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 84, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 84, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 84, column: 37]
@@ -6186,12 +5858,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 85, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 85, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 85, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 85, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 85, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 85, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 85, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 85, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 85, column: 37]
@@ -6261,12 +5929,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 86, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 86, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 86, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 86, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 86, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 86, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 86, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 86, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 86, column: 37]
@@ -6336,12 +6000,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 87, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 87, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 87, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 87, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 87, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 87, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 87, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 87, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 87, column: 37]
@@ -6411,12 +6071,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 88, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 88, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 88, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 88, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 88, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 88, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 88, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 88, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 88, column: 37]
@@ -6486,12 +6142,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 89, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 89, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 89, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 89, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 89, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 89, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 89, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 89, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 89, column: 37]
@@ -6561,12 +6213,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 90, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 90, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 90, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 90, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 90, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 90, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 90, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 90, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 90, column: 37]
@@ -6636,12 +6284,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 91, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 91, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 91, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 91, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 91, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 91, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 91, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 91, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 91, column: 37]
@@ -6711,12 +6355,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 92, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 92, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 92, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 92, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 92, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 92, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 92, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 92, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 92, column: 37]
@@ -6786,12 +6426,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 93, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 93, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 93, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 93, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 93, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 93, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 93, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 93, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 93, column: 37]
@@ -6861,12 +6497,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 94, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 94, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 94, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 94, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 94, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 94, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 94, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 94, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 94, column: 37]
@@ -6936,12 +6568,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 95, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 95, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 95, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 95, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 95, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 95, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 95, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 95, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 95, column: 37]
@@ -7011,12 +6639,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 96, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 96, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 96, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 96, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 96, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 96, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 96, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 96, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 96, column: 37]
@@ -7086,12 +6710,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 97, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 97, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 97, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 97, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 97, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 97, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 97, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 97, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 97, column: 37]
@@ -7161,12 +6781,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 98, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 98, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 98, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 98, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 98, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 98, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 98, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 98, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 98, column: 37]
@@ -7236,12 +6852,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 99, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 99, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 99, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 99, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 99, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 99, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 99, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 99, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 99, column: 37]
@@ -7311,12 +6923,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 100, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 100, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 100, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 100, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 100, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 100, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 100, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 100, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 100, column: 37]
@@ -7386,12 +6994,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 101, column: 17]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 101, column: 22]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 101, column: 26]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 101, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 101, column: 31]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 101, column: 32]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 101, column: 22]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 101, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 101, column: 37]
@@ -7461,12 +7065,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 102, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 102, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 102, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 102, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 102, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 102, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 102, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 102, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 102, column: 38]
@@ -7536,12 +7136,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 103, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 103, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 103, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 103, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 103, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 103, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 103, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 103, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 103, column: 38]
@@ -7611,12 +7207,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 104, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 104, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 104, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 104, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 104, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 104, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 104, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 104, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 104, column: 38]
@@ -7686,12 +7278,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 105, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 105, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 105, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 105, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 105, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 105, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 105, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 105, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 105, column: 38]
@@ -7761,12 +7349,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 106, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 106, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 106, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 106, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 106, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 106, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 106, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 106, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 106, column: 38]
@@ -7836,12 +7420,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 107, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 107, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 107, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 107, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 107, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 107, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 107, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 107, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 107, column: 38]
@@ -7911,12 +7491,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 108, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 108, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 108, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 108, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 108, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 108, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 108, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 108, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 108, column: 38]
@@ -7986,12 +7562,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 109, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 109, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 109, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 109, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 109, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 109, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 109, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 109, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 109, column: 38]
@@ -8061,12 +7633,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 110, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 110, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 110, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 110, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 110, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 110, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 110, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 110, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 110, column: 38]
@@ -8136,12 +7704,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 111, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 111, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 111, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 111, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 111, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 111, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 111, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 111, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 111, column: 38]
@@ -8211,12 +7775,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 112, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 112, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 112, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 112, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 112, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 112, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 112, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 112, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 112, column: 38]
@@ -8286,12 +7846,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 113, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 113, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 113, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 113, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 113, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 113, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 113, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 113, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 113, column: 38]
@@ -8361,12 +7917,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 114, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 114, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 114, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 114, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 114, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 114, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 114, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 114, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 114, column: 38]
@@ -8436,12 +7988,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 115, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 115, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 115, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 115, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 115, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 115, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 115, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 115, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 115, column: 38]
@@ -8511,12 +8059,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 116, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 116, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 116, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 116, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 116, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 116, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 116, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 116, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 116, column: 38]
@@ -8586,12 +8130,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 117, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 117, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 117, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 117, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 117, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 117, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 117, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 117, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 117, column: 38]
@@ -8661,12 +8201,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 118, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 118, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 118, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 118, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 118, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 118, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 118, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 118, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 118, column: 38]
@@ -8736,12 +8272,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 119, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 119, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 119, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 119, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 119, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 119, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 119, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 119, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 119, column: 38]
@@ -8811,12 +8343,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 120, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 120, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 120, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 120, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 120, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 120, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 120, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 120, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 120, column: 38]
@@ -8886,12 +8414,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 121, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 121, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 121, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 121, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 121, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 121, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 121, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 121, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 121, column: 38]
@@ -8961,12 +8485,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 122, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 122, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 122, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 122, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 122, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 122, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 122, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 122, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 122, column: 38]
@@ -9036,12 +8556,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 123, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 123, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 123, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 123, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 123, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 123, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 123, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 123, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 123, column: 38]
@@ -9111,12 +8627,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 124, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 124, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 124, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 124, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 124, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 124, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 124, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 124, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 124, column: 38]
@@ -9186,12 +8698,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 125, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 125, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 125, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 125, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 125, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 125, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 125, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 125, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 125, column: 38]
@@ -9261,12 +8769,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 126, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 126, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 126, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 126, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 126, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 126, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 126, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 126, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 126, column: 38]
@@ -9336,12 +8840,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 127, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 127, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 127, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 127, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 127, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 127, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 127, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 127, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 127, column: 38]
@@ -9411,12 +8911,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 128, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 128, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 128, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 128, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 128, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 128, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 128, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 128, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 128, column: 38]
@@ -9486,12 +8982,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 129, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 129, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 129, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 129, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 129, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 129, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 129, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 129, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 129, column: 38]
@@ -9561,12 +9053,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 130, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 130, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 130, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 130, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 130, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 130, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 130, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 130, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 130, column: 38]
@@ -9636,12 +9124,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 131, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 131, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 131, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 131, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 131, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 131, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 131, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 131, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 131, column: 38]
@@ -9711,12 +9195,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 132, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 132, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 132, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 132, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 132, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 132, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 132, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 132, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 132, column: 38]
@@ -9786,12 +9266,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 133, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 133, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 133, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 133, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 133, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 133, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 133, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 133, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 133, column: 38]
@@ -9861,12 +9337,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 134, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 134, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 134, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 134, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 134, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 134, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 134, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 134, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 134, column: 38]
@@ -9936,12 +9408,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 135, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 135, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 135, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 135, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 135, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 135, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 135, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 135, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 135, column: 38]
@@ -10011,12 +9479,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 136, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 136, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 136, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 136, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 136, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 136, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 136, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 136, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 136, column: 38]
@@ -10086,12 +9550,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 137, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 137, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 137, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 137, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 137, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 137, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 137, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 137, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 137, column: 38]
@@ -10161,12 +9621,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 138, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 138, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 138, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 138, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 138, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 138, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 138, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 138, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 138, column: 38]
@@ -10236,12 +9692,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 139, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 139, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 139, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 139, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 139, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 139, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 139, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 139, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 139, column: 38]
@@ -10311,12 +9763,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 140, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 140, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 140, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 140, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 140, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 140, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 140, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 140, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 140, column: 38]
@@ -10386,12 +9834,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 141, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 141, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 141, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 141, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 141, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 141, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 141, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 141, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 141, column: 38]
@@ -10461,12 +9905,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 142, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 142, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 142, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 142, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 142, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 142, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 142, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 142, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 142, column: 38]
@@ -10536,12 +9976,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 143, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 143, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 143, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 143, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 143, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 143, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 143, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 143, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 143, column: 38]
@@ -10611,12 +10047,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 144, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 144, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 144, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 144, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 144, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 144, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 144, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 144, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 144, column: 38]
@@ -10686,12 +10118,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 145, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 145, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 145, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 145, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 145, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 145, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 145, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 145, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 145, column: 38]
@@ -10761,12 +10189,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 146, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 146, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 146, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 146, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 146, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 146, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 146, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 146, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 146, column: 38]
@@ -10836,12 +10260,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 147, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 147, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 147, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 147, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 147, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 147, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 147, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 147, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 147, column: 38]
@@ -10911,12 +10331,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 148, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 148, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 148, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 148, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 148, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 148, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 148, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 148, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 148, column: 38]
@@ -10986,12 +10402,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 149, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 149, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 149, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 149, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 149, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 149, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 149, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 149, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 149, column: 38]
@@ -11061,12 +10473,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 150, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 150, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 150, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 150, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 150, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 150, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 150, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 150, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 150, column: 38]
@@ -11136,12 +10544,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 151, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 151, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 151, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 151, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 151, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 151, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 151, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 151, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 151, column: 38]
@@ -11211,12 +10615,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 152, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 152, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 152, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 152, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 152, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 152, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 152, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 152, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 152, column: 38]
@@ -11286,12 +10686,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 153, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 153, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 153, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 153, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 153, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 153, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 153, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 153, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 153, column: 38]
@@ -11361,12 +10757,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 154, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 154, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 154, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 154, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 154, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 154, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 154, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 154, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 154, column: 38]
@@ -11436,12 +10828,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 155, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 155, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 155, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 155, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 155, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 155, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 155, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 155, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 155, column: 38]
@@ -11511,12 +10899,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 156, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 156, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 156, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 156, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 156, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 156, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 156, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 156, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 156, column: 38]
@@ -11586,12 +10970,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 157, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 157, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 157, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 157, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 157, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 157, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 157, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 157, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 157, column: 38]
@@ -11661,12 +11041,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 158, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 158, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 158, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 158, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 158, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 158, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 158, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 158, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 158, column: 38]
@@ -11736,12 +11112,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 159, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 159, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 159, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 159, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 159, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 159, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 159, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 159, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 159, column: 38]
@@ -11811,12 +11183,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 160, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 160, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 160, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 160, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 160, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 160, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 160, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 160, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 160, column: 38]
@@ -11886,12 +11254,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 161, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 161, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 161, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 161, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 161, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 161, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 161, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 161, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 161, column: 38]
@@ -11961,12 +11325,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 162, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 162, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 162, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 162, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 162, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 162, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 162, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 162, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 162, column: 38]
@@ -12036,12 +11396,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 163, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 163, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 163, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 163, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 163, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 163, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 163, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 163, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 163, column: 38]
@@ -12111,12 +11467,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 164, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 164, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 164, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 164, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 164, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 164, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 164, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 164, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 164, column: 38]
@@ -12186,12 +11538,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 165, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 165, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 165, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 165, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 165, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 165, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 165, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 165, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 165, column: 38]
@@ -12261,12 +11609,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 166, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 166, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 166, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 166, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 166, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 166, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 166, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 166, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 166, column: 38]
@@ -12336,12 +11680,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 167, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 167, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 167, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 167, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 167, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 167, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 167, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 167, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 167, column: 38]
@@ -12411,12 +11751,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 168, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 168, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 168, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 168, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 168, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 168, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 168, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 168, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 168, column: 38]
@@ -12486,12 +11822,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 169, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 169, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 169, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 169, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 169, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 169, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 169, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 169, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 169, column: 38]
@@ -12561,12 +11893,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 170, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 170, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 170, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 170, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 170, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 170, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 170, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 170, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 170, column: 38]
@@ -12636,12 +11964,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 171, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 171, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 171, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 171, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 171, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 171, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 171, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 171, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 171, column: 38]
@@ -12711,12 +12035,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 172, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 172, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 172, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 172, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 172, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 172, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 172, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 172, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 172, column: 38]
@@ -12786,12 +12106,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 173, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 173, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 173, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 173, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 173, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 173, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 173, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 173, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 173, column: 38]
@@ -12861,12 +12177,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 174, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 174, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 174, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 174, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 174, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 174, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 174, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 174, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 174, column: 38]
@@ -12936,12 +12248,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 175, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 175, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 175, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 175, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 175, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 175, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 175, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 175, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 175, column: 38]
@@ -13011,12 +12319,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 176, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 176, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 176, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 176, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 176, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 176, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 176, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 176, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 176, column: 38]
@@ -13086,12 +12390,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 177, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 177, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 177, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 177, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 177, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 177, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 177, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 177, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 177, column: 38]
@@ -13161,12 +12461,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 178, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 178, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 178, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 178, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 178, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 178, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 178, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 178, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 178, column: 38]
@@ -13236,12 +12532,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 179, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 179, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 179, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 179, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 179, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 179, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 179, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 179, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 179, column: 38]
@@ -13311,12 +12603,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 180, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 180, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 180, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 180, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 180, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 180, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 180, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 180, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 180, column: 38]
@@ -13386,12 +12674,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 181, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 181, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 181, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 181, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 181, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 181, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 181, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 181, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 181, column: 38]
@@ -13461,12 +12745,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 182, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 182, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 182, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 182, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 182, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 182, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 182, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 182, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 182, column: 38]
@@ -13536,12 +12816,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 183, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 183, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 183, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 183, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 183, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 183, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 183, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 183, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 183, column: 38]
@@ -13611,12 +12887,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 184, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 184, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 184, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 184, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 184, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 184, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 184, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 184, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 184, column: 38]
@@ -13686,12 +12958,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 185, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 185, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 185, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 185, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 185, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 185, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 185, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 185, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 185, column: 38]
@@ -13761,12 +13029,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 186, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 186, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 186, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 186, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 186, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 186, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 186, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 186, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 186, column: 38]
@@ -13836,12 +13100,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 187, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 187, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 187, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 187, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 187, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 187, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 187, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 187, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 187, column: 38]
@@ -13911,12 +13171,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 188, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 188, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 188, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 188, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 188, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 188, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 188, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 188, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 188, column: 38]
@@ -13986,12 +13242,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 189, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 189, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 189, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 189, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 189, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 189, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 189, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 189, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 189, column: 38]
@@ -14061,12 +13313,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 190, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 190, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 190, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 190, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 190, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 190, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 190, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 190, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 190, column: 38]
@@ -14136,12 +13384,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 191, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 191, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 191, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 191, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 191, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 191, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 191, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 191, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 191, column: 38]
@@ -14211,12 +13455,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 192, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 192, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 192, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 192, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 192, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 192, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 192, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 192, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 192, column: 38]
@@ -14286,12 +13526,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 193, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 193, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 193, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 193, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 193, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 193, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 193, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 193, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 193, column: 38]
@@ -14361,12 +13597,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 194, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 194, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 194, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 194, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 194, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 194, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 194, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 194, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 194, column: 38]
@@ -14436,12 +13668,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 195, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 195, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 195, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 195, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 195, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 195, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 195, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 195, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 195, column: 38]
@@ -14511,12 +13739,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 196, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 196, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 196, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 196, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 196, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 196, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 196, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 196, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 196, column: 38]
@@ -14586,12 +13810,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 197, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 197, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 197, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 197, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 197, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 197, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 197, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 197, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 197, column: 38]
@@ -14661,12 +13881,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 198, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 198, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 198, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 198, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 198, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 198, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 198, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 198, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 198, column: 38]
@@ -14736,12 +13952,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 199, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 199, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 199, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 199, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 199, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 199, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 199, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 199, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 199, column: 38]
@@ -14811,12 +14023,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 200, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 200, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 200, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 200, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 200, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 200, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 200, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 200, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 200, column: 38]
@@ -14886,12 +14094,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 201, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 201, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 201, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 201, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 201, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 201, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 201, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 201, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 201, column: 38]
@@ -14961,12 +14165,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 202, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 202, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 202, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 202, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 202, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 202, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 202, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 202, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 202, column: 38]
@@ -15036,12 +14236,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 203, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 203, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 203, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 203, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 203, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 203, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 203, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 203, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 203, column: 38]
@@ -15111,12 +14307,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 204, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 204, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 204, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 204, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 204, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 204, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 204, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 204, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 204, column: 38]
@@ -15186,12 +14378,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 205, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 205, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 205, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 205, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 205, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 205, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 205, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 205, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 205, column: 38]
@@ -15261,12 +14449,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 206, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 206, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 206, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 206, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 206, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 206, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 206, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 206, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 206, column: 38]
@@ -15336,12 +14520,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 207, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 207, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 207, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 207, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 207, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 207, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 207, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 207, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 207, column: 38]
@@ -15411,12 +14591,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 208, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 208, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 208, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 208, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 208, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 208, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 208, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 208, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 208, column: 38]
@@ -15486,12 +14662,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 209, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 209, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 209, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 209, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 209, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 209, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 209, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 209, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 209, column: 38]
@@ -15561,12 +14733,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 210, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 210, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 210, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 210, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 210, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 210, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 210, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 210, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 210, column: 38]
@@ -15636,12 +14804,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 211, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 211, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 211, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 211, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 211, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 211, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 211, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 211, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 211, column: 38]
@@ -15711,12 +14875,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 212, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 212, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 212, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 212, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 212, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 212, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 212, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 212, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 212, column: 38]
@@ -15786,12 +14946,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 213, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 213, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 213, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 213, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 213, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 213, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 213, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 213, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 213, column: 38]
@@ -15861,12 +15017,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 214, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 214, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 214, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 214, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 214, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 214, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 214, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 214, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 214, column: 38]
@@ -15936,12 +15088,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 215, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 215, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 215, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 215, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 215, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 215, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 215, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 215, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 215, column: 38]
@@ -16011,12 +15159,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 216, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 216, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 216, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 216, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 216, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 216, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 216, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 216, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 216, column: 38]
@@ -16086,12 +15230,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 217, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 217, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 217, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 217, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 217, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 217, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 217, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 217, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 217, column: 38]
@@ -16161,12 +15301,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 218, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 218, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 218, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 218, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 218, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 218, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 218, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 218, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 218, column: 38]
@@ -16236,12 +15372,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 219, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 219, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 219, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 219, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 219, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 219, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 219, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 219, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 219, column: 38]
@@ -16311,12 +15443,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 220, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 220, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 220, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 220, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 220, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 220, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 220, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 220, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 220, column: 38]
@@ -16386,12 +15514,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 221, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 221, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 221, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 221, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 221, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 221, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 221, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 221, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 221, column: 38]
@@ -16461,12 +15585,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 222, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 222, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 222, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 222, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 222, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 222, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 222, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 222, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 222, column: 38]
@@ -16536,12 +15656,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 223, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 223, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 223, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 223, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 223, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 223, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 223, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 223, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 223, column: 38]
@@ -16611,12 +15727,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 224, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 224, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 224, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 224, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 224, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 224, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 224, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 224, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 224, column: 38]
@@ -16686,12 +15798,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 225, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 225, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 225, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 225, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 225, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 225, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 225, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 225, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 225, column: 38]
@@ -16761,12 +15869,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 226, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 226, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 226, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 226, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 226, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 226, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 226, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 226, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 226, column: 38]
@@ -16836,12 +15940,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 227, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 227, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 227, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 227, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 227, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 227, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 227, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 227, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 227, column: 38]
@@ -16911,12 +16011,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 228, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 228, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 228, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 228, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 228, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 228, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 228, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 228, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 228, column: 38]
@@ -16986,12 +16082,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 229, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 229, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 229, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 229, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 229, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 229, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 229, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 229, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 229, column: 38]
@@ -17061,12 +16153,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 230, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 230, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 230, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 230, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 230, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 230, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 230, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 230, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 230, column: 38]
@@ -17136,12 +16224,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 231, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 231, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 231, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 231, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 231, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 231, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 231, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 231, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 231, column: 38]
@@ -17211,12 +16295,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 232, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 232, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 232, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 232, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 232, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 232, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 232, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 232, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 232, column: 38]
@@ -17286,12 +16366,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 233, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 233, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 233, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 233, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 233, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 233, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 233, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 233, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 233, column: 38]
@@ -17361,12 +16437,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 234, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 234, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 234, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 234, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 234, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 234, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 234, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 234, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 234, column: 38]
@@ -17436,12 +16508,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 235, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 235, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 235, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 235, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 235, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 235, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 235, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 235, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 235, column: 38]
@@ -17511,12 +16579,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 236, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 236, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 236, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 236, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 236, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 236, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 236, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 236, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 236, column: 38]
@@ -17586,12 +16650,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 237, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 237, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 237, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 237, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 237, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 237, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 237, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 237, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 237, column: 38]
@@ -17661,12 +16721,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 238, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 238, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 238, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 238, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 238, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 238, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 238, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 238, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 238, column: 38]
@@ -17736,12 +16792,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 239, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 239, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 239, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 239, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 239, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 239, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 239, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 239, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 239, column: 38]
@@ -17811,12 +16863,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 240, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 240, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 240, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 240, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 240, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 240, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 240, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 240, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 240, column: 38]
@@ -17886,12 +16934,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 241, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 241, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 241, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 241, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 241, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 241, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 241, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 241, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 241, column: 38]
@@ -17961,12 +17005,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 242, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 242, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 242, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 242, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 242, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 242, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 242, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 242, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 242, column: 38]
@@ -18036,12 +17076,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 243, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 243, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 243, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 243, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 243, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 243, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 243, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 243, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 243, column: 38]
@@ -18111,12 +17147,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 244, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 244, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 244, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 244, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 244, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 244, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 244, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 244, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 244, column: 38]
@@ -18186,12 +17218,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 245, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 245, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 245, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 245, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 245, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 245, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 245, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 245, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 245, column: 38]
@@ -18261,12 +17289,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 246, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 246, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 246, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 246, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 246, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 246, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 246, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 246, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 246, column: 38]
@@ -18336,12 +17360,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 247, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 247, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 247, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 247, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 247, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 247, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 247, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 247, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 247, column: 38]
@@ -18411,12 +17431,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 248, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 248, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 248, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 248, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 248, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 248, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 248, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 248, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 248, column: 38]
@@ -18486,12 +17502,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 249, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 249, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 249, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 249, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 249, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 249, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 249, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 249, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 249, column: 38]
@@ -18561,12 +17573,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 250, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 250, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 250, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 250, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 250, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 250, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 250, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 250, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 250, column: 38]
@@ -18636,12 +17644,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 251, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 251, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 251, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 251, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 251, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 251, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 251, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 251, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 251, column: 38]
@@ -18711,12 +17715,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 252, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 252, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 252, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 252, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 252, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 252, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 252, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 252, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 252, column: 38]
@@ -18786,12 +17786,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 253, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 253, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 253, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 253, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 253, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 253, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 253, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 253, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 253, column: 38]
@@ -18861,12 +17857,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 254, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 254, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 254, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 254, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 254, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 254, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 254, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 254, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 254, column: 38]
@@ -18936,12 +17928,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 255, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 255, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 255, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 255, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 255, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 255, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 255, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 255, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 255, column: 38]
@@ -19011,12 +17999,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 256, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 256, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 256, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 256, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 256, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 256, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 256, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 256, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 256, column: 38]
@@ -19086,12 +18070,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 257, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 257, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 257, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 257, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 257, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 257, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 257, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 257, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 257, column: 38]
@@ -19161,12 +18141,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 258, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 258, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 258, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 258, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 258, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 258, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 258, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 258, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 258, column: 38]
@@ -19236,12 +18212,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 259, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 259, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 259, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 259, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 259, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 259, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 259, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 259, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 259, column: 38]
@@ -19311,12 +18283,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 260, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 260, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 260, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 260, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 260, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 260, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 260, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 260, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 260, column: 38]
@@ -19386,12 +18354,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 261, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 261, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 261, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 261, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 261, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 261, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 261, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 261, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 261, column: 38]
@@ -19461,12 +18425,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 262, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 262, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 262, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 262, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 262, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 262, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 262, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 262, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 262, column: 38]
@@ -19536,12 +18496,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 263, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 263, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 263, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 263, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 263, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 263, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 263, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 263, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 263, column: 38]
@@ -19611,12 +18567,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 264, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 264, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 264, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 264, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 264, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 264, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 264, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 264, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 264, column: 38]
@@ -19686,12 +18638,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 265, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 265, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 265, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 265, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 265, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 265, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 265, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 265, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 265, column: 38]
@@ -19761,12 +18709,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 266, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 266, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 266, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 266, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 266, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 266, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 266, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 266, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 266, column: 38]
@@ -19836,12 +18780,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 267, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 267, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 267, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 267, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 267, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 267, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 267, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 267, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 267, column: 38]
@@ -19911,12 +18851,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 268, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 268, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 268, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 268, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 268, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 268, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 268, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 268, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 268, column: 38]
@@ -19986,12 +18922,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 269, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 269, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 269, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 269, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 269, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 269, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 269, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 269, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 269, column: 38]
@@ -20061,12 +18993,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 270, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 270, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 270, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 270, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 270, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 270, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 270, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 270, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 270, column: 38]
@@ -20136,12 +19064,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 271, column: 18]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 271, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 271, column: 27]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 271, column: 28]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 271, column: 32]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 271, column: 33]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 271, column: 23]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 271, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 271, column: 38]
@@ -20215,12 +19139,8 @@
    |  |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 273, column: 11]
    |  |  |  |  |  |  '- reference
-   |  |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 273, column: 16]
-   |  |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 273, column: 20]
-   |  |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: lang, line: 273, column: 21]
-   |  |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 273, column: 25]
-   |  |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: String, line: 273, column: 26]
+   |  |  |  |  |  |     |- typeName
+   |  |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.lang.String, line: 273, column: 16]
    |  |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 273, column: 32]
    |  |  |  |  |  |     '- memberReference
    |  |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: substring, line: 273, column: 33]
@@ -20380,11 +19300,7 @@
    |  |  |     |  |     |- linkInlineTag
    |  |  |     |  |     |  |- TOKEN[type: LINK, text: link, line: 284, column: 21]
    |  |  |     |  |     |  '- reference
-   |  |  |     |  |     |     |- TOKEN[type: IDENTIFIER, text: java, line: 284, column: 26]
-   |  |  |     |  |     |     |- TOKEN[type: DOT, text: ., line: 284, column: 30]
-   |  |  |     |  |     |     |- TOKEN[type: IDENTIFIER, text: util, line: 284, column: 31]
-   |  |  |     |  |     |     |- TOKEN[type: DOT, text: ., line: 284, column: 35]
-   |  |  |     |  |     |     '- TOKEN[type: IDENTIFIER, text: Map, line: 284, column: 36]
+   |  |  |     |  |     |     '- TOKEN[type: IDENTIFIER, text: java.util.Map, line: 284, column: 26]
    |  |  |     |  |     '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 284, column: 39]
    |  |  |     |  '- htmlTagEnd
    |  |  |     |     |- TOKEN[type: TAG_OPEN, text: <, line: 284, column: 40]
@@ -20460,12 +19376,8 @@
    |  |  |  |- valueInlineTag
    |  |  |  |  |- TOKEN[type: VALUE, text: value, line: 288, column: 8]
    |  |  |  |  '- reference
-   |  |  |  |     |- qualifiedName
-   |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 288, column: 14]
-   |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 288, column: 18]
-   |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: lang, line: 288, column: 19]
-   |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 288, column: 23]
-   |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Integer, line: 288, column: 24]
+   |  |  |  |     |- typeName
+   |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.lang.Integer, line: 288, column: 14]
    |  |  |  |     |- TOKEN[type: HASH, text: #, line: 288, column: 31]
    |  |  |  |     '- memberReference
    |  |  |  |        '- TOKEN[type: IDENTIFIER, text: MAX_VALUE, line: 288, column: 32]
@@ -20571,12 +19483,8 @@
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |- linkInlineTag
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 304, column: 29]
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |  '- reference
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |- qualifiedName
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 304, column: 34]
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 304, column: 38]
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 304, column: 39]
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 304, column: 43]
-   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: List, line: 304, column: 44]
+   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |- typeName
+   |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 304, column: 34]
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 304, column: 48]
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |     '- memberReference
    |  |  |  |     |     |  |  |  |  |  |  |  |  |  |  |        |- TOKEN[type: IDENTIFIER, text: size, line: 304, column: 49]

--- a/src/test/resources/complex2.txt
+++ b/src/test/resources/complex2.txt
@@ -35,14 +35,14 @@
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 13, column: 3]
    |  |- TOKEN[type: THROWS, text: throws, line: 13, column: 4]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: IllegalArgumentException, line: 13, column: 11]
    |  '- description
    |     '- TOKEN[type: TEXT, text:  if something is null, line: 13, column: 35]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 14, column: 3]
    |  |- TOKEN[type: THROWS, text: throws, line: 14, column: 4]
-   |  |- qualifiedIdentifier
+   |  |- qualifiedName
    |  |  '- TOKEN[type: IDENTIFIER, text: NullPointerException, line: 14, column: 11]
    |  '- description
    |     '- TOKEN[type: TEXT, text:      if null sneaks in, line: 14, column: 31]
@@ -402,14 +402,8 @@
    |  |- TOKEN[type: AT_SIGN, text: @, line: 48, column: 3]
    |  |- TOKEN[type: SEE, text: see, line: 48, column: 4]
    |  '- reference
-   |     |- qualifiedName
-   |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 48, column: 8]
-   |     |  |- TOKEN[type: DOT, text: ., line: 48, column: 12]
-   |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 48, column: 13]
-   |     |  |- TOKEN[type: DOT, text: ., line: 48, column: 17]
-   |     |  |- TOKEN[type: IDENTIFIER, text: stream, line: 48, column: 18]
-   |     |  |- TOKEN[type: DOT, text: ., line: 48, column: 24]
-   |     |  '- TOKEN[type: IDENTIFIER, text: Stream, line: 48, column: 25]
+   |     |- typeName
+   |     |  '- TOKEN[type: IDENTIFIER, text: java.util.stream.Stream, line: 48, column: 8]
    |     |- TOKEN[type: HASH, text: #, line: 48, column: 31]
    |     '- memberReference
    |        |- TOKEN[type: IDENTIFIER, text: map, line: 48, column: 32]

--- a/src/test/resources/customBlockTag.txt
+++ b/src/test/resources/customBlockTag.txt
@@ -9,7 +9,7 @@
    |     |  |- linkInlineTag
    |     |  |  |- TOKEN[type: LINK, text: link, line: 1, column: 48]
    |     |  |  '- reference
-   |     |  |     |- qualifiedName
+   |     |  |     |- typeName
    |     |  |     |  '- TOKEN[type: IDENTIFIER, text: Math, line: 1, column: 53]
    |     |  |     |- TOKEN[type: HASH, text: #, line: 1, column: 57]
    |     |  |     '- memberReference

--- a/src/test/resources/html1.txt
+++ b/src/test/resources/html1.txt
@@ -63,12 +63,8 @@
    |     |  |  |  |- linkInlineTag
    |     |  |  |  |  |- TOKEN[type: LINK, text: link, line: 12, column: 10]
    |     |  |  |  |  '- reference
-   |     |  |  |  |     |- qualifiedName
-   |     |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 12, column: 15]
-   |     |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 19]
-   |     |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 12, column: 20]
-   |     |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 24]
-   |     |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Collections, line: 12, column: 25]
+   |     |  |  |  |     |- typeName
+   |     |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.Collections, line: 12, column: 15]
    |     |  |  |  |     |- TOKEN[type: HASH, text: #, line: 12, column: 36]
    |     |  |  |  |     '- memberReference
    |     |  |  |  |        |- TOKEN[type: IDENTIFIER, text: unmodifiableList, line: 12, column: 37]
@@ -92,11 +88,7 @@
    |     |     |  |- linkInlineTag
    |     |     |  |  |- TOKEN[type: LINK, text: link, line: 13, column: 10]
    |     |     |  |  '- reference
-   |     |     |  |     |- TOKEN[type: IDENTIFIER, text: java, line: 13, column: 15]
-   |     |     |  |     |- TOKEN[type: DOT, text: ., line: 13, column: 19]
-   |     |     |  |     |- TOKEN[type: IDENTIFIER, text: util, line: 13, column: 20]
-   |     |     |  |     |- TOKEN[type: DOT, text: ., line: 13, column: 24]
-   |     |     |  |     '- TOKEN[type: IDENTIFIER, text: ArrayList, line: 13, column: 25]
+   |     |     |  |     '- TOKEN[type: IDENTIFIER, text: java.util.ArrayList, line: 13, column: 15]
    |     |     |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 13, column: 34]
    |     |     '- htmlTagEnd
    |     |        |- TOKEN[type: TAG_OPEN, text: <, line: 13, column: 35]

--- a/src/test/resources/htmlNonTight4.txt
+++ b/src/test/resources/htmlNonTight4.txt
@@ -209,11 +209,7 @@
    |  |  |     |- linkInlineTag
    |  |  |     |  |- TOKEN[type: LINK, text: link, line: 26, column: 44]
    |  |  |     |  '- reference
-   |  |  |     |     |- TOKEN[type: IDENTIFIER, text: java, line: 26, column: 49]
-   |  |  |     |     |- TOKEN[type: DOT, text: ., line: 26, column: 53]
-   |  |  |     |     |- TOKEN[type: IDENTIFIER, text: util, line: 26, column: 54]
-   |  |  |     |     |- TOKEN[type: DOT, text: ., line: 26, column: 58]
-   |  |  |     |     '- TOKEN[type: IDENTIFIER, text: List, line: 26, column: 59]
+   |  |  |     |     '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 26, column: 49]
    |  |  |     '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 26, column: 63]
    |  |  '- htmlTagEnd
    |  |     |- TOKEN[type: TAG_OPEN, text: <, line: 26, column: 64]

--- a/src/test/resources/htmlNonTight6.txt
+++ b/src/test/resources/htmlNonTight6.txt
@@ -67,14 +67,8 @@
    |  |  |  |  |- linkInlineTag
    |  |  |  |  |  |- TOKEN[type: LINK, text: link, line: 8, column: 4]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 8, column: 9]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 8, column: 13]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 8, column: 14]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 8, column: 18]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: function, line: 8, column: 19]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 8, column: 27]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Function, line: 8, column: 28]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.function.Function, line: 8, column: 9]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 8, column: 36]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        '- TOKEN[type: IDENTIFIER, text: Function, line: 8, column: 37]
@@ -85,14 +79,8 @@
    |  |  |  |  |- linkPlainInlineTag
    |  |  |  |  |  |- TOKEN[type: LINKPLAIN, text: linkplain, line: 9, column: 4]
    |  |  |  |  |  '- reference
-   |  |  |  |  |     |- qualifiedName
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 9, column: 14]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 18]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 9, column: 19]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 23]
-   |  |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: stream, line: 9, column: 24]
-   |  |  |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 30]
-   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Stream, line: 9, column: 31]
+   |  |  |  |  |     |- typeName
+   |  |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: java.util.stream.Stream, line: 9, column: 14]
    |  |  |  |  |     |- TOKEN[type: HASH, text: #, line: 9, column: 37]
    |  |  |  |  |     '- memberReference
    |  |  |  |  |        '- TOKEN[type: IDENTIFIER, text: Stream, line: 9, column: 38]

--- a/src/test/resources/inheritDoc.txt
+++ b/src/test/resources/inheritDoc.txt
@@ -5,11 +5,7 @@
    |  |  |- inheritDocInlineTag
    |  |  |  |- TOKEN[type: INHERIT_DOC, text: inheritDoc, line: 1, column: 4]
    |  |  |  '- reference
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: java, line: 1, column: 15]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 1, column: 19]
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: util, line: 1, column: 20]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 1, column: 24]
-   |  |  |     '- TOKEN[type: IDENTIFIER, text: List, line: 1, column: 25]
+   |  |  |     '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 1, column: 15]
    |  |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 1, column: 29]
    |  |- inlineTag
    |  |  |- TOKEN[type: JAVADOC_INLINE_TAG_START, text: {@, line: 2, column: 2]
@@ -21,10 +17,6 @@
    |     |- inheritDocInlineTag
    |     |  |- TOKEN[type: INHERIT_DOC, text: inheritDoc, line: 3, column: 4]
    |     |  '- reference
-   |     |     |- TOKEN[type: IDENTIFIER, text: java, line: 4, column: 12]
-   |     |     |- TOKEN[type: DOT, text: ., line: 4, column: 16]
-   |     |     |- TOKEN[type: IDENTIFIER, text: util, line: 4, column: 17]
-   |     |     |- TOKEN[type: DOT, text: ., line: 4, column: 21]
-   |     |     '- TOKEN[type: IDENTIFIER, text: List, line: 4, column: 22]
+   |     |     '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 4, column: 12]
    |     '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 4, column: 26]
    '- TOKEN[type: EOF, text: <EOF>, line: 5, column: 0]

--- a/src/test/resources/inlineLink1.txt
+++ b/src/test/resources/inlineLink1.txt
@@ -12,18 +12,14 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 2, column: 4]
    |  |  |  '- reference
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: com, line: 2, column: 9]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 2, column: 12]
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: example, line: 2, column: 13]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 2, column: 20]
-   |  |  |     '- TOKEN[type: IDENTIFIER, text: MyClass, line: 2, column: 21]
+   |  |  |     '- TOKEN[type: IDENTIFIER, text: com.example.MyClass, line: 2, column: 9]
    |  |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 2, column: 28]
    |  |- inlineTag
    |  |  |- TOKEN[type: JAVADOC_INLINE_TAG_START, text: {@, line: 3, column: 2]
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 3, column: 4]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
+   |  |  |     |- typeName
    |  |  |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 3, column: 9]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 3, column: 16]
    |  |  |     '- memberReference
@@ -34,12 +30,8 @@
    |     |- linkInlineTag
    |     |  |- TOKEN[type: LINK, text: link, line: 4, column: 4]
    |     |  '- reference
-   |     |     |- qualifiedName
-   |     |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 4, column: 9]
-   |     |     |  |- TOKEN[type: DOT, text: ., line: 4, column: 12]
-   |     |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 4, column: 13]
-   |     |     |  |- TOKEN[type: DOT, text: ., line: 4, column: 20]
-   |     |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 4, column: 21]
+   |     |     |- typeName
+   |     |     |  '- TOKEN[type: IDENTIFIER, text: com.example.MyClass, line: 4, column: 9]
    |     |     |- TOKEN[type: HASH, text: #, line: 4, column: 28]
    |     |     '- memberReference
    |     |        '- TOKEN[type: IDENTIFIER, text: myMethod, line: 4, column: 29]

--- a/src/test/resources/inlineLink2.txt
+++ b/src/test/resources/inlineLink2.txt
@@ -5,12 +5,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 1, column: 4]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 1, column: 9]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 1, column: 12]
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 1, column: 13]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 1, column: 20]
-   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 1, column: 21]
+   |  |  |     |- typeName
+   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: com.example.MyClass, line: 1, column: 9]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 1, column: 28]
    |  |  |     '- memberReference
    |  |  |        |- TOKEN[type: IDENTIFIER, text: myMethod, line: 1, column: 29]
@@ -22,7 +18,7 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 2, column: 4]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
+   |  |  |     |- typeName
    |  |  |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 2, column: 9]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 2, column: 16]
    |  |  |     '- memberReference
@@ -35,7 +31,7 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 3, column: 4]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
+   |  |  |     |- typeName
    |  |  |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 3, column: 9]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 3, column: 16]
    |  |  |     '- memberReference
@@ -50,10 +46,8 @@
    |     |- linkInlineTag
    |     |  |- TOKEN[type: LINK, text: link, line: 4, column: 4]
    |     |  '- reference
-   |     |     |- qualifiedName
-   |     |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 4, column: 9]
-   |     |     |  |- TOKEN[type: DOT, text: ., line: 4, column: 16]
-   |     |     |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 4, column: 17]
+   |     |     |- typeName
+   |     |     |  '- TOKEN[type: IDENTIFIER, text: example.MyClass, line: 4, column: 9]
    |     |     |- TOKEN[type: HASH, text: #, line: 4, column: 24]
    |     |     '- memberReference
    |     |        |- TOKEN[type: IDENTIFIER, text: myMethod, line: 4, column: 25]

--- a/src/test/resources/inlineLink3.txt
+++ b/src/test/resources/inlineLink3.txt
@@ -5,12 +5,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 1, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: com, line: 1, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 12]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: example, line: 1, column: 13]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 20]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: MyClass, line: 1, column: 21]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: com.example.MyClass, line: 1, column: 9]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 1, column: 28]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: myMethod, line: 1, column: 29]
@@ -56,7 +52,7 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 4, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- qualifiedName
+   |  |  |  |  |- typeName
    |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Class, line: 4, column: 9]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 4, column: 14]
    |  |  |  |  '- memberReference
@@ -75,14 +71,8 @@
    |     |- linkInlineTag
    |     |  |- TOKEN[type: LINK, text: link, line: 5, column: 4]
    |     |  |- reference
-   |     |  |  |- qualifiedName
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: com, line: 5, column: 9]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 12]
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: example, line: 5, column: 13]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 20]
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 5, column: 21]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 25]
-   |     |  |  |  '- TOKEN[type: IDENTIFIER, text: MathUtils, line: 5, column: 26]
+   |     |  |  |- typeName
+   |     |  |  |  '- TOKEN[type: IDENTIFIER, text: com.example.util.MathUtils, line: 5, column: 9]
    |     |  |  |- TOKEN[type: HASH, text: #, line: 5, column: 35]
    |     |  |  '- memberReference
    |     |  |     |- TOKEN[type: IDENTIFIER, text: calculateScore, line: 5, column: 36]

--- a/src/test/resources/inlineLink4.txt
+++ b/src/test/resources/inlineLink4.txt
@@ -7,16 +7,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 2, column: 4]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 2, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 13]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: base, line: 2, column: 14]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.base, line: 2, column: 9]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 2, column: 18]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 2, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 23]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 2, column: 24]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 28]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Optional, line: 2, column: 29]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Optional, line: 2, column: 19]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 2, column: 37]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: ifPresentOrElse, line: 2, column: 38]
@@ -60,16 +54,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 7, column: 8]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 7, column: 13]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 7, column: 17]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: base, line: 7, column: 18]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.base, line: 7, column: 13]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 7, column: 22]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 7, column: 23]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 7, column: 27]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 7, column: 28]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 7, column: 32]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: List, line: 7, column: 33]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 7, column: 23]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 7, column: 37]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: Test, line: 7, column: 38]
@@ -128,12 +116,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 15, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 15, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 15, column: 13]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 15, column: 14]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 15, column: 18]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Arrays, line: 15, column: 19]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Arrays, line: 15, column: 9]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 15, column: 25]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: copyOf, line: 15, column: 26]
@@ -156,16 +140,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 19, column: 4]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 19, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 19, column: 13]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: base, line: 19, column: 14]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.base, line: 19, column: 9]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 19, column: 18]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 19, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 19, column: 23]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: lang, line: 19, column: 24]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 19, column: 28]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: String, line: 19, column: 29]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.lang.String, line: 19, column: 19]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 19, column: 35]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: substring, line: 19, column: 36]
@@ -186,18 +164,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 23, column: 4]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 23, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 23, column: 13]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: logging, line: 23, column: 14]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.logging, line: 23, column: 9]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 23, column: 21]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 23, column: 22]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 23, column: 26]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 23, column: 27]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 23, column: 31]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: logging, line: 23, column: 32]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 23, column: 39]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Logger, line: 23, column: 40]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.logging.Logger, line: 23, column: 22]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 23, column: 46]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: getLogger, line: 23, column: 47]
@@ -222,18 +192,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 27, column: 4]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 27, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 27, column: 13]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: base, line: 27, column: 14]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.base, line: 27, column: 9]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 27, column: 18]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 27, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 27, column: 23]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 27, column: 24]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 27, column: 28]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: function, line: 27, column: 29]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 27, column: 37]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Function, line: 27, column: 38]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.function.Function, line: 27, column: 19]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 27, column: 46]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: apply, line: 27, column: 47]
@@ -252,18 +214,10 @@
    |  |  |  |- TOKEN[type: LINK, text: link, line: 31, column: 4]
    |  |  |  |- reference
    |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 31, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 31, column: 13]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: base, line: 31, column: 14]
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.base, line: 31, column: 9]
    |  |  |  |  |- TOKEN[type: SLASH, text: /, line: 31, column: 18]
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 31, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 31, column: 23]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 31, column: 24]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 31, column: 28]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: stream, line: 31, column: 29]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 31, column: 35]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Stream, line: 31, column: 36]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.stream.Stream, line: 31, column: 19]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 31, column: 42]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: map, line: 31, column: 43]
@@ -281,14 +235,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 35, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 35, column: 9]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 35, column: 13]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 35, column: 14]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 35, column: 18]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: Map, line: 35, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 35, column: 22]
-   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Entry, line: 35, column: 23]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Map.Entry, line: 35, column: 9]
    |  |  |  |  |- TOKEN[type: HASH, text: #, line: 35, column: 28]
    |  |  |  |  '- memberReference
    |  |  |  |     |- TOKEN[type: IDENTIFIER, text: getKey, line: 35, column: 29]
@@ -311,11 +259,7 @@
    |     |- linkInlineTag
    |     |  |- TOKEN[type: LINK, text: link, line: 39, column: 4]
    |     |  |- reference
-   |     |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 39, column: 9]
-   |     |  |  |- TOKEN[type: DOT, text: ., line: 39, column: 13]
-   |     |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 39, column: 14]
-   |     |  |  |- TOKEN[type: DOT, text: ., line: 39, column: 18]
-   |     |  |  '- TOKEN[type: IDENTIFIER, text: Arrays, line: 39, column: 19]
+   |     |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Arrays, line: 39, column: 9]
    |     |  '- description
    |     |     '- TOKEN[type: TEXT, text:  array, line: 39, column: 25]
    |     '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 39, column: 31]

--- a/src/test/resources/inlineLink5.txt
+++ b/src/test/resources/inlineLink5.txt
@@ -5,12 +5,9 @@
    |  |  |- linkPlainInlineTag
    |  |  |  |- TOKEN[type: LINKPLAIN, text: linkplain, line: 1, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- qualifiedName
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 1, column: 14]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 18]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 1, column: 19]
-   |  |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 23]
-   |  |  |  |  |  |- TOKEN[type: IDENTIFIER, text: Map, line: 1, column: 24]
+   |  |  |  |  |- typeName
+   |  |  |  |  |  |- qualifiedName
+   |  |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Map, line: 1, column: 14]
    |  |  |  |  |  '- typeArguments
    |  |  |  |  |     |- TOKEN[type: LT, text: <, line: 1, column: 27]
    |  |  |  |  |     |- typeArgument
@@ -37,13 +34,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 2, column: 13]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 2, column: 18]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 22]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 2, column: 23]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 27]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: function, line: 2, column: 28]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 36]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: Function, line: 2, column: 37]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.function.Function, line: 2, column: 18]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 2, column: 45]
    |  |  |  |     |- typeArgument
@@ -61,25 +53,24 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 3, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 3, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 3, column: 13]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 3, column: 14]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 3, column: 18]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: Map, line: 3, column: 19]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Map, line: 3, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 3, column: 22]
    |  |  |  |     |- typeArgument
    |  |  |  |     |  '- TOKEN[type: IDENTIFIER, text: String, line: 3, column: 23]
    |  |  |  |     |- TOKEN[type: COMMA, text: ,, line: 3, column: 29]
    |  |  |  |     |- typeArgument
-   |  |  |  |     |  |- TOKEN[type: IDENTIFIER, text: Map, line: 3, column: 31]
+   |  |  |  |     |  |- qualifiedName
+   |  |  |  |     |  |  '- TOKEN[type: IDENTIFIER, text: Map, line: 3, column: 31]
    |  |  |  |     |  '- typeArguments
    |  |  |  |     |     |- TOKEN[type: LT, text: <, line: 3, column: 34]
    |  |  |  |     |     |- typeArgument
    |  |  |  |     |     |  '- TOKEN[type: IDENTIFIER, text: String, line: 3, column: 35]
    |  |  |  |     |     |- TOKEN[type: COMMA, text: ,, line: 3, column: 41]
    |  |  |  |     |     |- typeArgument
-   |  |  |  |     |     |  |- TOKEN[type: IDENTIFIER, text: List, line: 3, column: 43]
+   |  |  |  |     |     |  |- qualifiedName
+   |  |  |  |     |     |  |  '- TOKEN[type: IDENTIFIER, text: List, line: 3, column: 43]
    |  |  |  |     |     |  '- typeArguments
    |  |  |  |     |     |     |- TOKEN[type: LT, text: <, line: 3, column: 47]
    |  |  |  |     |     |     |- typeArgument
@@ -95,11 +86,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 4, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: com, line: 4, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 12]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: example, line: 4, column: 13]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 20]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: MyBox, line: 4, column: 21]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: com.example.MyBox, line: 4, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 4, column: 26]
    |  |  |  |     |- typeArgument
@@ -113,14 +101,9 @@
    |     |- linkPlainInlineTag
    |     |  |- TOKEN[type: LINKPLAIN, text: linkplain, line: 5, column: 4]
    |     |  |- reference
-   |     |  |  |- qualifiedName
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 5, column: 14]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 18]
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 5, column: 19]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 23]
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: concurrent, line: 5, column: 24]
-   |     |  |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 34]
-   |     |  |  |  |- TOKEN[type: IDENTIFIER, text: CompletableFuture, line: 5, column: 35]
+   |     |  |  |- typeName
+   |     |  |  |  |- qualifiedName
+   |     |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.concurrent.CompletableFuture, line: 5, column: 14]
    |     |  |  |  '- typeArguments
    |     |  |  |     |- TOKEN[type: LT, text: <, line: 5, column: 52]
    |     |  |  |     |- typeArgument

--- a/src/test/resources/inlineLink6.txt
+++ b/src/test/resources/inlineLink6.txt
@@ -5,11 +5,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 1, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 1, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 13]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 1, column: 14]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 1, column: 18]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: List, line: 1, column: 19]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 1, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 1, column: 23]
    |  |  |  |     |- typeArgument
@@ -23,11 +20,8 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 2, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 2, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 13]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 2, column: 14]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 2, column: 18]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: List, line: 2, column: 19]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 2, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 2, column: 23]
    |  |  |  |     |- typeArgument
@@ -41,17 +35,14 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 3, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 3, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 3, column: 13]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 3, column: 14]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 3, column: 18]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: List, line: 3, column: 19]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 3, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 3, column: 23]
    |  |  |  |     |- typeArgument
    |  |  |  |     |  |- TOKEN[type: QUESTION, text: ?, line: 3, column: 24]
    |  |  |  |     |  |- TOKEN[type: EXTENDS, text: extends, line: 3, column: 26]
-   |  |  |  |     |  '- qualifiedName
+   |  |  |  |     |  '- typeName
    |  |  |  |     |     '- TOKEN[type: IDENTIFIER, text: Number, line: 3, column: 34]
    |  |  |  |     '- TOKEN[type: GT, text: >, line: 3, column: 40]
    |  |  |  '- description
@@ -62,17 +53,14 @@
    |  |  |- linkInlineTag
    |  |  |  |- TOKEN[type: LINK, text: link, line: 4, column: 4]
    |  |  |  |- reference
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 4, column: 9]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 13]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 4, column: 14]
-   |  |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 18]
-   |  |  |  |  |- TOKEN[type: IDENTIFIER, text: List, line: 4, column: 19]
+   |  |  |  |  |- qualifiedName
+   |  |  |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 4, column: 9]
    |  |  |  |  '- typeArguments
    |  |  |  |     |- TOKEN[type: LT, text: <, line: 4, column: 23]
    |  |  |  |     |- typeArgument
    |  |  |  |     |  |- TOKEN[type: QUESTION, text: ?, line: 4, column: 24]
    |  |  |  |     |  |- TOKEN[type: SUPER, text: super, line: 4, column: 26]
-   |  |  |  |     |  '- qualifiedName
+   |  |  |  |     |  '- typeName
    |  |  |  |     |     '- TOKEN[type: IDENTIFIER, text: Integer, line: 4, column: 32]
    |  |  |  |     '- TOKEN[type: GT, text: >, line: 4, column: 39]
    |  |  |  '- description
@@ -83,11 +71,8 @@
    |     |- linkInlineTag
    |     |  |- TOKEN[type: LINK, text: link, line: 5, column: 4]
    |     |  |- reference
-   |     |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 5, column: 9]
-   |     |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 13]
-   |     |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 5, column: 14]
-   |     |  |  |- TOKEN[type: DOT, text: ., line: 5, column: 18]
-   |     |  |  |- TOKEN[type: IDENTIFIER, text: Map, line: 5, column: 19]
+   |     |  |  |- qualifiedName
+   |     |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.Map, line: 5, column: 9]
    |     |  |  '- typeArguments
    |     |  |     |- TOKEN[type: LT, text: <, line: 5, column: 22]
    |     |  |     |- typeArgument
@@ -96,7 +81,7 @@
    |     |  |     |- typeArgument
    |     |  |     |  |- TOKEN[type: QUESTION, text: ?, line: 5, column: 31]
    |     |  |     |  |- TOKEN[type: EXTENDS, text: extends, line: 5, column: 33]
-   |     |  |     |  '- qualifiedName
+   |     |  |     |  '- typeName
    |     |  |     |     '- TOKEN[type: IDENTIFIER, text: Number, line: 5, column: 41]
    |     |  |     '- TOKEN[type: GT, text: >, line: 5, column: 47]
    |     |  '- description

--- a/src/test/resources/inlineReturn.txt
+++ b/src/test/resources/inlineReturn.txt
@@ -40,7 +40,7 @@
    |  |  |     |  |- linkInlineTag
    |  |  |     |  |  |- TOKEN[type: LINK, text: link, line: 4, column: 34]
    |  |  |     |  |  |- reference
-   |  |  |     |  |  |  |- qualifiedName
+   |  |  |     |  |  |  |- typeName
    |  |  |     |  |  |  |  '- TOKEN[type: IDENTIFIER, text: Opcode, line: 4, column: 39]
    |  |  |     |  |  |  |- TOKEN[type: HASH, text: #, line: 4, column: 45]
    |  |  |     |  |  |  '- memberReference

--- a/src/test/resources/inlineSummary.txt
+++ b/src/test/resources/inlineSummary.txt
@@ -110,12 +110,8 @@
    |  |  |     |  |- valueInlineTag
    |  |  |     |  |  |- TOKEN[type: VALUE, text: value, line: 11, column: 4]
    |  |  |     |  |  '- reference
-   |  |  |     |  |     |- qualifiedName
-   |  |  |     |  |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 11, column: 10]
-   |  |  |     |  |     |  |- TOKEN[type: DOT, text: ., line: 11, column: 14]
-   |  |  |     |  |     |  |- TOKEN[type: IDENTIFIER, text: lang, line: 11, column: 15]
-   |  |  |     |  |     |  |- TOKEN[type: DOT, text: ., line: 11, column: 19]
-   |  |  |     |  |     |  '- TOKEN[type: IDENTIFIER, text: Math, line: 11, column: 20]
+   |  |  |     |  |     |- typeName
+   |  |  |     |  |     |  '- TOKEN[type: IDENTIFIER, text: java.lang.Math, line: 11, column: 10]
    |  |  |     |  |     |- TOKEN[type: HASH, text: #, line: 11, column: 24]
    |  |  |     |  |     '- memberReference
    |  |  |     |  |        '- TOKEN[type: IDENTIFIER, text: PI, line: 11, column: 25]
@@ -133,11 +129,8 @@
    |     |        |- linkInlineTag
    |     |        |  |- TOKEN[type: LINK, text: link, line: 12, column: 32]
    |     |        |  |- reference
-   |     |        |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 12, column: 37]
-   |     |        |  |  |- TOKEN[type: DOT, text: ., line: 12, column: 41]
-   |     |        |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 12, column: 42]
-   |     |        |  |  |- TOKEN[type: DOT, text: ., line: 12, column: 46]
-   |     |        |  |  |- TOKEN[type: IDENTIFIER, text: List, line: 12, column: 47]
+   |     |        |  |  |- qualifiedName
+   |     |        |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 12, column: 37]
    |     |        |  |  '- typeArguments
    |     |        |  |     |- TOKEN[type: LT, text: <, line: 12, column: 51]
    |     |        |  |     |- typeArgument

--- a/src/test/resources/seeTag.txt
+++ b/src/test/resources/seeTag.txt
@@ -5,21 +5,13 @@
    |  |- TOKEN[type: AT_SIGN, text: @, line: 3, column: 2]
    |  |- TOKEN[type: SEE, text: see, line: 3, column: 3]
    |  '- reference
-   |     |- TOKEN[type: IDENTIFIER, text: java, line: 3, column: 7]
-   |     |- TOKEN[type: DOT, text: ., line: 3, column: 11]
-   |     |- TOKEN[type: IDENTIFIER, text: lang, line: 3, column: 12]
-   |     |- TOKEN[type: DOT, text: ., line: 3, column: 16]
-   |     '- TOKEN[type: IDENTIFIER, text: String, line: 3, column: 17]
+   |     '- TOKEN[type: IDENTIFIER, text: java.lang.String, line: 3, column: 7]
    |- blockTag
    |  |- TOKEN[type: AT_SIGN, text: @, line: 4, column: 2]
    |  |- TOKEN[type: SEE, text: see, line: 4, column: 3]
    |  |- reference
-   |  |  |- qualifiedName
-   |  |  |  |- TOKEN[type: IDENTIFIER, text: java, line: 4, column: 7]
-   |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 11]
-   |  |  |  |- TOKEN[type: IDENTIFIER, text: util, line: 4, column: 12]
-   |  |  |  |- TOKEN[type: DOT, text: ., line: 4, column: 16]
-   |  |  |  '- TOKEN[type: IDENTIFIER, text: List, line: 4, column: 17]
+   |  |  |- typeName
+   |  |  |  '- TOKEN[type: IDENTIFIER, text: java.util.List, line: 4, column: 7]
    |  |  |- TOKEN[type: HASH, text: #, line: 4, column: 21]
    |  |  '- memberReference
    |  |     |- TOKEN[type: IDENTIFIER, text: add, line: 4, column: 22]
@@ -33,12 +25,8 @@
    |  |- TOKEN[type: AT_SIGN, text: @, line: 5, column: 2]
    |  |- TOKEN[type: SEE, text: see, line: 5, column: 3]
    |  '- reference
-   |     |- qualifiedName
-   |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 5, column: 7]
-   |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 11]
-   |     |  |- TOKEN[type: IDENTIFIER, text: util, line: 5, column: 12]
-   |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 16]
-   |     |  '- TOKEN[type: IDENTIFIER, text: Map, line: 5, column: 17]
+   |     |- typeName
+   |     |  '- TOKEN[type: IDENTIFIER, text: java.util.Map, line: 5, column: 7]
    |     |- TOKEN[type: HASH, text: #, line: 5, column: 20]
    |     '- memberReference
    |        |- TOKEN[type: IDENTIFIER, text: put, line: 5, column: 21]
@@ -108,7 +96,7 @@
    |  |- TOKEN[type: AT_SIGN, text: @, line: 11, column: 2]
    |  |- TOKEN[type: SEE, text: see, line: 11, column: 3]
    |  |- reference
-   |  |  |- qualifiedName
+   |  |  |- typeName
    |  |  |  '- TOKEN[type: IDENTIFIER, text: Field, line: 11, column: 7]
    |  |  |- TOKEN[type: HASH, text: #, line: 11, column: 12]
    |  |  '- memberReference
@@ -121,12 +109,8 @@
    |  |- TOKEN[type: AT_SIGN, text: @, line: 12, column: 2]
    |  |- TOKEN[type: SEE, text: see, line: 12, column: 3]
    |  '- reference
-   |     |- qualifiedName
-   |     |  |- TOKEN[type: IDENTIFIER, text: java, line: 12, column: 11]
-   |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 15]
-   |     |  |- TOKEN[type: IDENTIFIER, text: lang, line: 12, column: 16]
-   |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 20]
-   |     |  '- TOKEN[type: IDENTIFIER, text: System, line: 12, column: 21]
+   |     |- typeName
+   |     |  '- TOKEN[type: IDENTIFIER, text: java.lang.System, line: 12, column: 11]
    |     |- TOKEN[type: HASH, text: #, line: 12, column: 27]
    |     '- memberReference
    |        |- TOKEN[type: IDENTIFIER, text: getProperty, line: 12, column: 28]

--- a/src/test/resources/systemPropertyTag.txt
+++ b/src/test/resources/systemPropertyTag.txt
@@ -5,12 +5,8 @@
    |  |  |- TOKEN[type: JAVADOC_INLINE_TAG_START, text: {@, line: 1, column: 27]
    |  |  |- systemPropertyInlineTag
    |  |  |  |- TOKEN[type: SYSTEM_PROPERTY, text: systemProperty, line: 1, column: 29]
-   |  |  |  '- propertyName
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: java, line: 1, column: 44]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 1, column: 48]
-   |  |  |     |- TOKEN[type: IDENTIFIER, text: io, line: 1, column: 49]
-   |  |  |     |- TOKEN[type: DOT, text: ., line: 1, column: 51]
-   |  |  |     '- TOKEN[type: IDENTIFIER, text: tmpdir, line: 1, column: 52]
+   |  |  |  '- qualifiedName
+   |  |  |     '- TOKEN[type: IDENTIFIER, text: java.io.tmpdir, line: 1, column: 44]
    |  |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 1, column: 58]
    |  |- TOKEN[type: TEXT, text:  system property,, line: 1, column: 59]
    |  |- TOKEN[type: TEXT, text: which specifies the default temporary file directory., line: 2, column: 2]
@@ -19,7 +15,7 @@
    |  |  |- TOKEN[type: JAVADOC_INLINE_TAG_START, text: {@, line: 3, column: 27]
    |  |  |- systemPropertyInlineTag
    |  |  |  |- TOKEN[type: SYSTEM_PROPERTY, text: systemProperty, line: 3, column: 29]
-   |  |  |  '- propertyName
+   |  |  |  '- qualifiedName
    |  |  |     '- TOKEN[type: IDENTIFIER, text: java, line: 3, column: 44]
    |  |  '- TOKEN[type: JAVADOC_INLINE_TAG_END, text: }, line: 3, column: 48]
    |  |- TOKEN[type: TEXT, text:  system property,, line: 3, column: 49]

--- a/src/test/resources/valueInlineTag.txt
+++ b/src/test/resources/valueInlineTag.txt
@@ -24,12 +24,8 @@
    |  |  |- valueInlineTag
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 3, column: 15]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 3, column: 21]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 3, column: 24]
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 3, column: 25]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 3, column: 32]
-   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 3, column: 33]
+   |  |  |     |- typeName
+   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: com.example.Constants, line: 3, column: 21]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 3, column: 42]
    |  |  |     '- memberReference
    |  |  |        '- TOKEN[type: IDENTIFIER, text: TIMEOUT_MS, line: 3, column: 43]
@@ -50,12 +46,8 @@
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 5, column: 15]
    |  |  |  |- TOKEN[type: FORMAT_SPECIFIER, text: %.2f, line: 5, column: 21]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 5, column: 26]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 29]
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 5, column: 30]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 5, column: 37]
-   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 5, column: 38]
+   |  |  |     |- typeName
+   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: com.example.Constants, line: 5, column: 26]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 5, column: 47]
    |  |  |     '- memberReference
    |  |  |        '- TOKEN[type: IDENTIFIER, text: PI, line: 5, column: 48]
@@ -67,7 +59,7 @@
    |  |  |- valueInlineTag
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 6, column: 15]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
+   |  |  |     |- typeName
    |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 6, column: 21]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 6, column: 30]
    |  |  |     '- memberReference
@@ -81,7 +73,7 @@
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 7, column: 15]
    |  |  |  |- TOKEN[type: FORMAT_SPECIFIER, text: %.1f, line: 7, column: 21]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
+   |  |  |     |- typeName
    |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 7, column: 26]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 7, column: 35]
    |  |  |     '- memberReference
@@ -95,12 +87,8 @@
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 8, column: 15]
    |  |  |  |- TOKEN[type: FORMAT_SPECIFIER, text: %.2f, line: 8, column: 21]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 9, column: 16]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 19]
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 9, column: 20]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 9, column: 27]
-   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 9, column: 28]
+   |  |  |     |- typeName
+   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: com.example.Constants, line: 9, column: 16]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 9, column: 37]
    |  |  |     '- memberReference
    |  |  |        '- TOKEN[type: IDENTIFIER, text: PI, line: 9, column: 38]
@@ -113,12 +101,8 @@
    |  |  |  |- TOKEN[type: VALUE, text: value, line: 10, column: 15]
    |  |  |  |- TOKEN[type: FORMAT_SPECIFIER, text: %.2f, line: 11, column: 16]
    |  |  |  '- reference
-   |  |  |     |- qualifiedName
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: com, line: 12, column: 16]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 19]
-   |  |  |     |  |- TOKEN[type: IDENTIFIER, text: example, line: 12, column: 20]
-   |  |  |     |  |- TOKEN[type: DOT, text: ., line: 12, column: 27]
-   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: Constants, line: 12, column: 28]
+   |  |  |     |- typeName
+   |  |  |     |  '- TOKEN[type: IDENTIFIER, text: com.example.Constants, line: 12, column: 16]
    |  |  |     |- TOKEN[type: HASH, text: #, line: 12, column: 37]
    |  |  |     '- memberReference
    |  |  |        '- TOKEN[type: IDENTIFIER, text: PI, line: 12, column: 38]


### PR DESCRIPTION
This PR refines the grammar to simplify identifier handling and improve qualified name parsing. It replaces `DOT` tokens with a unified qualified name parsing approach and removes redundant rules.

### Rationale:

- Simplifies the parser by consolidating qualified name logic
- Eliminates the need to track dot-separated identifiers manually
- Reduces grammar complexity and parse tree size

### Grammar Changes

* Unified the parsing of identifiers by replacing the `DOT` token and combining it into a single rule for qualified names (`IDENTIFIER: ([a-zA-Z0-9_$] | '.')+`). This eliminates the need for separate handling of dots in identifiers. 
* Removed the `DOT` token and related rules.
* Modified the `qualifiedName` rule in the parser to simplify parsing by removing the `DOT IDENTIFIER` sequence and allowing identifiers to include dots directly (`IDENTIFIER typeArguments?`).